### PR TITLE
Add return type to fft

### DIFF
--- a/src/lib/transform/fft.ts
+++ b/src/lib/transform/fft.ts
@@ -1,6 +1,8 @@
 // @ts-ignore
 import { fft as _fft } from 'fftjs'
 
-export const fft = (buffer: Float64Array) => {
+export const fft = (
+  buffer: Float64Array
+): { real: Float64Array; imag: Float64Array } => {
   return _fft(buffer)
 }


### PR DESCRIPTION
Hey 👋

I've noticed that the `fft` function from `lib/transform/fft.ts` doesn't have a return type going along with it.
Because of the `@ts-ignore` and no type information for `_fft` it shows up as `any` for me.

I'd love to add the type annotations for with this PR.